### PR TITLE
midi: create index-reader command

### DIFF
--- a/src/midi/command.rs
+++ b/src/midi/command.rs
@@ -1,5 +1,5 @@
 extern crate portmidi;
-pub use portmidi::MidiEvent;
+pub use portmidi::{MidiEvent, MidiMessage};
 
 use super::{Error, InputPort, OutputPort};
 
@@ -17,6 +17,30 @@ impl Reader for InputPort<'_> {
 impl<'a> Reader for (InputPort<'a>, OutputPort<'a>) {
     fn read(&mut self) -> Result<Option<MidiEvent>, Error> {
         return Reader::read(&mut self.0);
+    }
+}
+
+/// MIDI Device that can expose an unsigned integer
+/// The default implementation will follow the chromatic scale, starting from C2,
+/// but this gives specific vendors to provide a more relevant implementation.
+pub trait IndexReader {
+    fn read_index(&mut self) -> Result<Option<u16>, Error>;
+}
+
+impl IndexReader for InputPort<'_> {
+    fn read_index(&mut self) -> Result<Option<u16>, Error> {
+        return Reader::read(self).map(|event| {
+            return event.filter(|event| event.message.status == 144)
+                // a note above C2 (36) must have been read with a strictly positive velocity
+                .filter(|event| event.message.data1 >= 36 && event.message.data2 > 0)
+                .map(|event| (event.message.data1 - 36) as u16);
+        });
+    }
+}
+
+impl<'a> IndexReader for (InputPort<'a>, OutputPort<'a>) {
+    fn read_index(&mut self) -> Result<Option<u16>, Error> {
+        return IndexReader::read_index(&mut self.0);
     }
 }
 

--- a/src/midi/launchpadpro/mod.rs
+++ b/src/midi/launchpadpro/mod.rs
@@ -1,6 +1,6 @@
 use std::convert::From;
 use crate::image::Pixel;
-use super::{InputPort, OutputPort, MidiEvent, Error, Reader, Writer, ImageRenderer};
+use super::{InputPort, OutputPort, MidiEvent, Error, Reader, Writer, ImageRenderer, IndexReader};
 
 pub struct LaunchpadPro<'a> {
     input_port: InputPort<'a>,
@@ -12,7 +12,7 @@ impl LaunchpadPro<'_> {
     /// logic internal.
     pub fn map_index(i: u8) -> u8 {
         let index = if i > 63 {
-            63 
+            63
         } else {
             i
         };
@@ -37,6 +37,33 @@ impl Reader for LaunchpadPro<'_> {
     fn read(&mut self) -> Result<Option<MidiEvent>, Error> {
         return Reader::read(&mut self.input_port);
     }
+}
+
+impl IndexReader for LaunchpadPro<'_> {
+    fn read_index(&mut self) -> Result<Option<u16>, Error> {
+        return Reader::read(self).map(|event| event.and_then(|event| map_event_to_index(event)));
+    }
+}
+
+pub fn map_event_to_index(event: MidiEvent) -> Option<u16> {
+    return Some(event)
+        // event must be a "note down"
+        .filter(|event| event.message.status == 144)
+        // event must have a strictly positive velocity
+        .filter(|event| event.message.data2 > 0)
+        // event must correspond to a square pad
+        // then map the index by starting from the grid’s bottom-left corner
+        .and_then(|event| {
+            let value = event.message.data1;
+            let row = value / 10;
+            let column  = value % 10;
+
+            if row >= 1 && row <= 8 && column >= 1 && column <= 8 {
+                return Some((row - 1) * 8 + (column - 1)).map(|index| index.into());
+            } else {
+                return None;
+            }
+        });
 }
 
 impl Writer for LaunchpadPro<'_> {
@@ -64,7 +91,7 @@ impl ImageRenderer<Vec<Pixel>> for LaunchpadPro<'_> {
             .flat_map(|pixel| vec![pixel.r / 4, pixel.g / 4, pixel.b / 4])
             .collect();
 
-        let mut picture = vec![240, 0, 32, 41, 2, 16, 15, 1]; 
+        let mut picture = vec![240, 0, 32, 41, 2, 16, 15, 1];
         picture.append(&mut transformed_pixels);
         picture.append(&mut vec![247]);
 
@@ -74,13 +101,74 @@ impl ImageRenderer<Vec<Pixel>> for LaunchpadPro<'_> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "launchpadpro")]
 mod tests {
-    use crate::midi::Connections;
+    use super::super::MidiMessage;
     use super::*;
 
     #[test]
+    fn map_event_to_index_given_incorrect_status_should_return_none() {
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([128, 53, 10, 0]))));
+    }
+
+    #[test]
+    fn map_event_to_index_given_low_velocity_should_return_none() {
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 53, 0, 0]))));
+    }
+
+    #[test]
+    fn map_event_to_index_given_out_of_grid_value_should_return_none() {
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 00, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 01, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 08, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 08, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 10, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 19, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 80, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 89, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 90, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 91, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 98, 10, 0]))));
+        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 99, 10, 0]))));
+    }
+
+    #[test]
+    fn map_event_to_index_should_correct_value() {
+        let actual_output = vec![
+            81, 82, 83, 84, 85, 86, 87, 88,
+            71, 72, 73, 74, 75, 76, 77, 78,
+            61, 62, 63, 64, 65, 66, 67, 68,
+            51, 52, 53, 54, 55, 56, 57, 58,
+            41, 42, 43, 44, 45, 46, 47, 48,
+            31, 32, 33, 34, 35, 36, 37, 38,
+            21, 22, 23, 24, 25, 26, 27, 28,
+            11, 12, 13, 14, 15, 16, 17, 18,
+        ]
+            .iter()
+            .map(|code| map_event_to_index(MidiEvent::from(MidiMessage::from([144, *code, 10, 0]))))
+            .collect::<Vec<Option<u16>>>();
+
+        let expected_output = vec![
+            56, 57, 58, 59, 60, 61, 62, 63,
+            48, 49, 50, 51, 52, 53, 54, 55,
+            40, 41, 42, 43, 44, 45, 46, 47,
+            32, 33, 34, 35, 36, 37, 38, 39,
+            24, 25, 26, 27, 28, 29, 30, 31,
+            16, 17, 18, 19, 20, 21, 22, 23,
+            08, 09, 10, 11, 12, 13, 14, 15,
+            00, 01, 02, 03, 04, 05, 06, 07,
+        ]
+            .iter()
+            .map(|index| Some(*index))
+            .collect::<Vec<Option<u16>>>();
+
+        assert_eq!(expected_output, actual_output);
+    }
+
+    #[test]
+    #[cfg(feature = "launchpadpro")]
     fn render_rainbow() {
+        use crate::midi::Connections;
+
         let connections = Connections::new().unwrap();
         let ports = connections.create_bidirectional_ports(&"Launchpad Pro Standalone Port".to_string());
         match ports {


### PR DESCRIPTION
One more pull request trying to improve test coverage while organizing the code structure a bit.

Midi Hub will now assign notes from C2 upwards to indices 0 upwards by default, but leave the flexibility to vendors to implement a more relevant logic. For instance, on the Programmer layout of the Launchpad Pro, the device sends MIDI events that correspond to the coordinates of the square pads on the grid controller rather than notes (see the [documentation](https://fael-downloads-prod.focusrite.com/customer/prod/s3fs-public/downloads/Launchpad%20Pro%20Programmers%20Reference%20Guide%201.01.pdf)).