### PR TITLE
Create router

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,40 +2,19 @@ extern crate portmidi as pm;
 extern crate signal_hook as sh;
 
 use std::env;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
 
 mod spotify;
 mod image;
 mod midi;
-use midi::{Connections, Error, InputPort, OutputPort, Reader, Writer, ImageRenderer, IndexReader};
-use midi::launchpadpro::LaunchpadPro;
-
-const MIDI_DEVICE_POLL_INTERVAL: Duration = Duration::from_millis(10_000);
-const MIDI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+mod router;
 
 enum Config {
     LoginConfig {
         config: spotify::SpotifyAppConfig,
     },
     RunConfig {
-        config: RunConfig,
+        config: router::RunConfig,
     },
-}
-
-struct RunConfig {
-    spotify_app_config: spotify::SpotifyAppConfig,
-    input_name: String,
-    output_name: String,
-    spotify_selector: String,
-}
-
-struct Ports<'a> {
-    input: Result<InputPort<'a>, Error>,
-    output: Result<OutputPort<'a>, Error>,
-    spotify: Result<LaunchpadPro<'a>, Error>,
 }
 
 fn main() {
@@ -50,18 +29,7 @@ fn main() {
                     })
                     .map_err(|()| String::from("Could not log in"));
             },
-            Config::RunConfig { config } => {
-                let ref term = Arc::new(AtomicBool::new(false));
-                println!("Press ^C or send SIGINT to terminate the program");
-                let _sigint = sh::flag::register(sh::consts::signal::SIGINT, Arc::clone(term));
-
-                let task_spawner = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone());
-                let mut inner_result = Ok(());
-                while !term.load(Ordering::Relaxed) && inner_result.is_ok() {
-                    inner_result = cycle(&config, &task_spawner, Instant::now(), term);
-                }
-                return inner_result.map_err(|err| format!("{}", err));
-            },
+            Config::RunConfig { config } => router::run(&config).map_err(|err| format!("{}", err)),
         }
     });
 
@@ -93,7 +61,7 @@ fn args() -> Result<Config, String> {
         Some("run") => {
             return match &args[2..] {
                 [client_id, client_secret, input_name, output_name, spotify_selector, playlist_id, token] => Ok(Config::RunConfig {
-                    config: RunConfig {
+                    config: router::RunConfig {
                         spotify_app_config: spotify::SpotifyAppConfig {
                             authorization: spotify::authorization::SpotifyAuthorizationConfig {
                                 client_id: String::from(client_id),
@@ -111,81 +79,5 @@ fn args() -> Result<Config, String> {
             };
         },
         _ => Err(String::from("Usage ./midi-hub [login|run] <args>")),
-    };
-}
-
-fn cycle(
-    config: &RunConfig,
-    task_spawner: &spotify::SpotifyTaskSpawner,
-    start: Instant,
-    term: &Arc<AtomicBool>,
-) -> Result<(), Error> {
-    return Connections::new().and_then(|connections| {
-        let ports = select_ports(&connections, &config);
-        let mut result = Ok(());
-        match ports {
-            Ports { input: Ok(mut input_port), output: Ok(mut output_port), spotify: _ } => {
-                while !term.load(Ordering::Relaxed)
-                    && result.is_ok()
-                    && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL
-                {
-                    result = forward_events(&mut input_port, &mut output_port);
-                    thread::sleep(MIDI_EVENT_POLL_INTERVAL);
-                }
-            },
-            Ports { input: _, output: _, spotify: Ok(mut ports) } => {
-                while !term.load(Ordering::Relaxed)
-                    && result.is_ok()
-                    && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL
-                {
-                    let selected_covers = task_spawner.selected_covers();
-                    match selected_covers {
-                        Some(images) => {
-                            let _ = ports.render(images);
-                        },
-                        None => {},
-                    }
-                    result = send_spotify_tasks(task_spawner, &mut ports);
-                    thread::sleep(MIDI_EVENT_POLL_INTERVAL);
-                }
-            },
-            _ => {
-                println!("Could not find the configured ports");
-                thread::sleep(MIDI_DEVICE_POLL_INTERVAL);
-            },
-        }
-        return result;
-    });
-}
-
-fn select_ports<'a, 'b, 'c>(
-    connections: &'a Connections,
-    config: &'b RunConfig,
-) -> Ports<'a> {
-    let input = connections.create_input_port(&config.input_name);
-    let output = connections.create_output_port(&config.output_name);
-    let spotify = connections.create_bidirectional_ports(&config.spotify_selector)
-        .map(|ports| LaunchpadPro::from(ports));
-
-    return Ports { input, output, spotify };
-}
-
-fn forward_events<R: Reader, W: Writer>(reader: &mut R, writer: &mut W) -> Result<(), Error> {
-    return match reader.read() {
-        Ok(Some(e)) => {
-            println!("MIDI event: {:?}", e);
-            return writer.write(&e);
-        },
-        _ => Ok(()),
-    };
-}
-
-fn send_spotify_tasks<IR: IndexReader>(task_spawner: &spotify::SpotifyTaskSpawner, spotify_reader: &mut IR) -> Result<(), Error> {
-    return match spotify_reader.read_index() {
-        Ok(Some(index)) => {
-            task_spawner.spawn_task(spotify::SpotifyTask::Play { index: index.into() });
-            return Ok(());
-        },
-        _ => Ok(()),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,10 @@ fn main() {
                     })
                     .map_err(|()| String::from("Could not log in"));
             },
-            Config::RunConfig { config } => router::run(&config).map_err(|err| format!("{}", err)),
+            Config::RunConfig { config } => {
+                let router = router::Router::new(config);
+                router.run().map_err(|err| format!("{}", err))
+            }
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,7 @@ fn main() {
     let result = args().and_then(|config| {
         match config {
             Config::LoginConfig { config } => {
-                let task_spawner = spotify::SpotifyTaskSpawner::new(config.clone());
-                return task_spawner.login_sync().and_then(|token| token.refresh_token.ok_or(()))
+                return spotify::SpotifyTaskSpawner::login_sync(config.clone()).and_then(|token| token.refresh_token.ok_or(()))
                     .map(|refresh_token| {
                         println!("Please use this refresh token to start the service: {:?}", refresh_token);
                         return ();
@@ -30,7 +29,7 @@ fn main() {
                     .map_err(|()| String::from("Could not log in"));
             },
             Config::RunConfig { config } => {
-                let router = router::Router::new(config);
+                let mut router = router::Router::new(config);
                 router.run().map_err(|err| format!("{}", err))
             }
         }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use crate::spotify;
 use crate::midi;
-use midi::{Connections, Error, Reader, Writer, ImageRenderer, IndexReader};
+use midi::{Connections, Error, Writer, ImageRenderer, IndexReader};
 use midi::launchpadpro::LaunchpadPro;
 
 const MIDI_DEVICE_POLL_INTERVAL: Duration = Duration::from_millis(10_000);
@@ -20,81 +20,87 @@ pub struct RunConfig {
     pub spotify_selector: String,
 }
 
-pub fn run(config: &RunConfig) -> Result<(), Error> {
-    let ref term = Arc::new(AtomicBool::new(false));
-    println!("Press ^C or send SIGINT to terminate the program");
-    let _sigint = sh::flag::register(sh::consts::signal::SIGINT, Arc::clone(term));
+pub struct Router {
+    config: RunConfig,
+    term: Arc<AtomicBool>,
+    spotify_spawner: spotify::SpotifyTaskSpawner,
+}
 
-    let task_spawner = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone());
-    let mut inner_result = Ok(());
-    while !term.load(Ordering::Relaxed) && inner_result.is_ok() {
-        inner_result = cycle(&config, &task_spawner, Instant::now(), term);
+impl Router {
+    pub fn new(config: RunConfig) -> Self {
+        let term = Arc::new(AtomicBool::new(false));
+
+        let spotify_spawner = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone());
+
+        return Router {
+            config,
+            term,
+            spotify_spawner,
+        };
     }
-    return inner_result;
-}
 
-fn cycle(
-    config: &RunConfig,
-    task_spawner: &spotify::SpotifyTaskSpawner,
-    start: Instant,
-    term: &Arc<AtomicBool>,
-) -> Result<(), Error> {
-    return Connections::new().and_then(|connections| {
-        let mut input = connections.create_input_port(&config.input_name);
-        let mut output = connections.create_output_port(&config.output_name);
-        let mut spotify = connections.create_bidirectional_ports(&config.spotify_selector)
-            .map(|ports| LaunchpadPro::from(ports));
+    pub fn run(&self) -> Result<(), Error> {
+        println!("Press ^C or send SIGINT to terminate the program");
+        let _sigint = sh::flag::register(sh::consts::signal::SIGINT, Arc::clone(&self.term));
 
-        let mut result = Ok(());
-
-        while !term.load(Ordering::Relaxed) && result.is_ok() && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL {
-            let forward_result = match (input.as_mut(), output.as_mut()) {
-                (Ok(i), Ok(o)) => forward_events(i, o),
-                (Err(e), _) => Err(*e),
-                (_, Err(e)) => Err(*e),
-            };
-
-            let spotify_result = match spotify.as_mut() {
-                Ok(spotify) => {
-                    let selected_covers = task_spawner.selected_covers();
-                    match selected_covers {
-                        Some(images) => {
-                            let _ = spotify.render(images);
-                        },
-                        None => {},
-                    }
-                    send_spotify_tasks(task_spawner, spotify)
-                },
-                Err(e) => Err(*e),
-            };
-
-            result = forward_result.or(spotify_result);
-            match result {
-                Ok(_) => thread::sleep(MIDI_EVENT_POLL_INTERVAL),
-                _ => thread::sleep(MIDI_DEVICE_POLL_INTERVAL),
-            }
+        let mut inner_result = Ok(());
+        while !self.term.load(Ordering::Relaxed) && inner_result.is_ok() {
+            inner_result = self.run_one_cycle(Instant::now());
         }
+        return inner_result;
+    }
 
-        return result;
-    });
-}
+    fn run_one_cycle(&self, start: Instant) -> Result<(), Error> {
+        return Connections::new().and_then(|connections| {
+            let mut input = connections.create_input_port(&self.config.input_name);
+            let mut output = connections.create_output_port(&self.config.output_name);
+            let mut spotify = connections.create_bidirectional_ports(&self.config.spotify_selector)
+                .map(|ports| LaunchpadPro::from(ports));
 
-fn forward_events<R: Reader, W: Writer>(reader: &mut R, writer: &mut W) -> Result<(), Error> {
-    return match reader.read() {
-        Ok(Some(e)) => {
-            println!("MIDI event: {:?}", e);
-            return writer.write(&e);
-        },
-        _ => Ok(()),
-    };
-}
+            let mut result = Ok(());
 
-fn send_spotify_tasks<IR: IndexReader>(task_spawner: &spotify::SpotifyTaskSpawner, spotify_reader: &mut IR) -> Result<(), Error> {
-    return match spotify_reader.read_index() {
-        Ok(Some(index)) => {
-            task_spawner.spawn_task(spotify::SpotifyTask::Play { index: index.into() });
-            return Ok(());
-        },
-        _ => Ok(()),
-    };
+            while !self.term.load(Ordering::Relaxed) && result.is_ok() && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL {
+                let forward_result = match (input.as_mut(), output.as_mut()) {
+                    (Ok(i), Ok(o)) => match i.read() {
+                        Ok(Some(e)) => {
+                            println!("MIDI event: {:?}", e);
+                            o.write(&e)
+                        },
+                        _ => Ok(()),
+                    },
+                    (Err(e), _) => Err(*e),
+                    (_, Err(e)) => Err(*e),
+                };
+
+                let spotify_result = match spotify.as_mut() {
+                    Ok(spotify) => {
+                        let selected_covers = self.spotify_spawner.selected_covers();
+                        match selected_covers {
+                            Some(images) => {
+                                let _ = spotify.render(images);
+                            },
+                            None => {},
+                        }
+
+                        match spotify.read_index() {
+                            Ok(Some(index)) => {
+                                self.spotify_spawner.spawn_task(spotify::SpotifyTask::Play { index: index.into()  });
+                                Ok(())
+                            },
+                            _ => Ok(()),
+                        }
+                    },
+                    Err(e) => Err(*e),
+                };
+
+                result = forward_result.or(spotify_result);
+                match result {
+                    Ok(_) => thread::sleep(MIDI_EVENT_POLL_INTERVAL),
+                    _ => thread::sleep(MIDI_DEVICE_POLL_INTERVAL),
+                }
+            }
+
+            return result;
+        });
+    }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,0 +1,116 @@
+extern crate signal_hook as sh;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::spotify;
+use crate::midi;
+use midi::{Connections, Error, InputPort, OutputPort, Reader, Writer, ImageRenderer, IndexReader};
+use midi::launchpadpro::LaunchpadPro;
+
+const MIDI_DEVICE_POLL_INTERVAL: Duration = Duration::from_millis(10_000);
+const MIDI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub struct RunConfig {
+    pub spotify_app_config: spotify::SpotifyAppConfig,
+    pub input_name: String,
+    pub output_name: String,
+    pub spotify_selector: String,
+}
+
+struct Ports<'a> {
+    input: Result<InputPort<'a>, Error>,
+    output: Result<OutputPort<'a>, Error>,
+    spotify: Result<LaunchpadPro<'a>, Error>,
+}
+
+pub fn run(config: &RunConfig) -> Result<(), Error> {
+    let ref term = Arc::new(AtomicBool::new(false));
+    println!("Press ^C or send SIGINT to terminate the program");
+    let _sigint = sh::flag::register(sh::consts::signal::SIGINT, Arc::clone(term));
+
+    let task_spawner = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone());
+    let mut inner_result = Ok(());
+    while !term.load(Ordering::Relaxed) && inner_result.is_ok() {
+        inner_result = cycle(&config, &task_spawner, Instant::now(), term);
+    }
+    return inner_result;
+}
+
+fn cycle(
+    config: &RunConfig,
+    task_spawner: &spotify::SpotifyTaskSpawner,
+    start: Instant,
+    term: &Arc<AtomicBool>,
+) -> Result<(), Error> {
+    return Connections::new().and_then(|connections| {
+        let ports = select_ports(&connections, &config);
+        let mut result = Ok(());
+        match ports {
+            Ports { input: Ok(mut input_port), output: Ok(mut output_port), spotify: _ } => {
+                while !term.load(Ordering::Relaxed)
+                    && result.is_ok()
+                    && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL
+                {
+                    result = forward_events(&mut input_port, &mut output_port);
+                    thread::sleep(MIDI_EVENT_POLL_INTERVAL);
+                }
+            },
+            Ports { input: _, output: _, spotify: Ok(mut ports) } => {
+                while !term.load(Ordering::Relaxed)
+                    && result.is_ok()
+                    && start.elapsed() < MIDI_DEVICE_POLL_INTERVAL
+                {
+                    let selected_covers = task_spawner.selected_covers();
+                    match selected_covers {
+                        Some(images) => {
+                            let _ = ports.render(images);
+                        },
+                        None => {},
+                    }
+                    result = send_spotify_tasks(task_spawner, &mut ports);
+                    thread::sleep(MIDI_EVENT_POLL_INTERVAL);
+                }
+            },
+            _ => {
+                println!("Could not find the configured ports");
+                thread::sleep(MIDI_DEVICE_POLL_INTERVAL);
+            },
+        }
+        return result;
+    });
+}
+
+fn select_ports<'a, 'b, 'c>(
+    connections: &'a Connections,
+    config: &'b RunConfig,
+) -> Ports<'a> {
+    let input = connections.create_input_port(&config.input_name);
+    let output = connections.create_output_port(&config.output_name);
+    let spotify = connections.create_bidirectional_ports(&config.spotify_selector)
+        .map(|ports| LaunchpadPro::from(ports));
+
+    return Ports { input, output, spotify };
+}
+
+fn forward_events<R: Reader, W: Writer>(reader: &mut R, writer: &mut W) -> Result<(), Error> {
+    return match reader.read() {
+        Ok(Some(e)) => {
+            println!("MIDI event: {:?}", e);
+            return writer.write(&e);
+        },
+        _ => Ok(()),
+    };
+}
+
+fn send_spotify_tasks<IR: IndexReader>(task_spawner: &spotify::SpotifyTaskSpawner, spotify_reader: &mut IR) -> Result<(), Error> {
+    return match spotify_reader.read_index() {
+        Ok(Some(index)) => {
+            task_spawner.spawn_task(spotify::SpotifyTask::Play { index: index.into() });
+            return Ok(());
+        },
+        _ => Ok(()),
+    };
+}


### PR DESCRIPTION
The router’s responsibility is to decouple MIDI devices from the applications that use them. This pull request is a first step towards this goal, it introduces an actor model that we can iterate on to make the router agnostic on the events that the application needs to read while making it possible for these applications to communicate back commands to be forwarded to the MIDI devices by the router in a generic way.