### PR TITLE
Migrate event transformation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     let result = args().and_then(|config| {
         match config {
             Config::LoginConfig { config } => {
-                return spotify::SpotifyTaskSpawner::login_sync(config.clone()).and_then(|token| token.refresh_token.ok_or(()))
+                return spotify::login_sync(config.clone()).and_then(|token| token.refresh_token.ok_or(()))
                     .map(|refresh_token| {
                         println!("Please use this refresh token to start the service: {:?}", refresh_token);
                         return ();

--- a/src/midi/command.rs
+++ b/src/midi/command.rs
@@ -1,67 +1,31 @@
-extern crate portmidi;
-pub use portmidi::{MidiEvent, MidiMessage};
-
-use super::{Error, InputPort, OutputPort};
-
-/// MIDI Device that is able to emit MIDI events
-pub trait Reader {
-    fn read(&mut self) -> Result<Option<MidiEvent>, Error>;
-}
-
-impl Reader for InputPort<'_> {
-    fn read(&mut self) -> Result<Option<MidiEvent>, Error> {
-        return self.read().map_err(|_| Error::ReadError);
-    }
-}
-
-impl<'a> Reader for (InputPort<'a>, OutputPort<'a>) {
-    fn read(&mut self) -> Result<Option<MidiEvent>, Error> {
-        return Reader::read(&mut self.0);
-    }
-}
+use crate::image::Image;
+use super::Error;
 
 /// MIDI Device that can expose an unsigned integer
 /// The default implementation will follow the chromatic scale, starting from C2,
 /// but this gives specific vendors to provide a more relevant implementation.
-pub trait IndexReader {
-    fn read_index(&mut self) -> Result<Option<u16>, Error>;
+pub trait IntoIndex {
+    fn into_index(self) -> Result<Option<u16>, Error>;
 }
 
-impl IndexReader for InputPort<'_> {
-    fn read_index(&mut self) -> Result<Option<u16>, Error> {
-        return Reader::read(self).map(|event| {
-            return event.filter(|event| event.message.status == 144)
-                // a note above C2 (36) must have been read with a strictly positive velocity
-                .filter(|event| event.message.data1 >= 36 && event.message.data2 > 0)
-                .map(|event| (event.message.data1 - 36) as u16);
-        });
-    }
-}
-
-impl<'a> IndexReader for (InputPort<'a>, OutputPort<'a>) {
-    fn read_index(&mut self) -> Result<Option<u16>, Error> {
-        return IndexReader::read_index(&mut self.0);
-    }
-}
-
-/// MIDI Device that is able to receive MIDI events
-pub trait Writer {
-    fn write(&mut self, event: &MidiEvent) -> Result<(), Error>;
-}
-
-impl Writer for OutputPort<'_> {
-    fn write(&mut self, event: &MidiEvent) -> Result<(), Error> {
-        return self.write_event(*event).map_err(|_| Error::WriteError);
-    }
-}
-
-impl<'a> Writer for (InputPort<'a>, OutputPort<'a>) {
-    fn write(&mut self, event: &MidiEvent) -> Result<(), Error> {
-        return Writer::write(&mut self.1, event);
+impl IntoIndex for [u8; 4] {
+    fn into_index(self) ->  Result<Option<u16>, Error> {
+        return match self {
+            // filter "note down" events, for notes higher than C2 (36), and with a strictly positive velocity
+            [144, data1, data2, _] if data1 < 36 && data2 > 0 => {
+                Ok(Some((data1 - 36).into()))
+            },
+            _ => Ok(None),
+        };
     }
 }
 
 /// MIDI Device that is able to render a picture
-pub trait ImageRenderer<P> {
-    fn render(&mut self, image: P) -> Result<(), Error>;
+pub trait FromImage<T> {
+    fn from_image(image: Image) -> Result<T, Error>;
+}
+
+/// MIDI Deviĉe that is able to render a collection of pictures
+pub trait FromImages<T> {
+    fn from_images(images: Vec<Image>) -> Result<T, Error>;
 }

--- a/src/midi/device.rs
+++ b/src/midi/device.rs
@@ -5,6 +5,7 @@ use portmidi::{MidiEvent, MidiMessage};
 
 use super::{Error, InputPort, OutputPort};
 
+#[derive(Clone, Debug)]
 pub enum Event {
     Midi([u8; 4]),
     SysEx(Vec<u8>),

--- a/src/midi/device.rs
+++ b/src/midi/device.rs
@@ -1,0 +1,68 @@
+use std::convert::{From, Into};
+
+extern crate portmidi;
+use portmidi::{MidiEvent, MidiMessage};
+
+use super::{Error, InputPort, OutputPort};
+
+pub enum Event {
+    Midi([u8; 4]),
+    SysEx(Vec<u8>),
+}
+
+/// MIDI Device that is able to emit MIDI events
+pub trait Reader<E> where E: From<Event> {
+    fn read_midi(&mut self) -> Result<Option<[u8; 4]>, Error>;
+    fn read(&mut self) -> Result<Option<E>, Error> {
+        let midi = self.read_midi()?;
+        return Ok(midi.map(|m| Event::Midi(m).into()));
+    }
+}
+
+impl Reader<Event> for InputPort<'_> {
+    fn read_midi(&mut self) -> Result<Option<[u8; 4]>, Error> {
+        return self.read()
+            .map(|event| 
+                event.map(|e| [e.message.status, e.message.data1, e.message.data2, e.message.data3]))
+            .map_err(|_| Error::ReadError);
+    }
+}
+
+impl<'a> Reader<Event> for (InputPort<'a>, OutputPort<'a>) {
+    fn read_midi(&mut self) -> Result<Option<[u8; 4]>, Error> {
+        return Reader::read_midi(&mut self.0);
+    }
+}
+
+/// MIDI Device that is able to receive MIDI events and SysEx MIDI messages
+pub trait Writer<E> where E: Into<Event> {
+    fn write_midi(&mut self, event: &[u8; 4]) -> Result<(), Error>;
+    fn write_sysex(&mut self, event: &[u8]) -> Result<(), Error>;
+
+    fn write(&mut self, event: E) -> Result<(), Error> {
+        return match event.into() {
+            Event::Midi(event) => self.write_midi(&event),
+            Event::SysEx(event) => self.write_sysex(&event),
+        };
+    }
+}
+
+impl Writer<Event> for OutputPort<'_> {
+    fn write_midi(&mut self, event: &[u8; 4]) -> Result<(), Error> {
+        return self.write_event(MidiEvent::from(MidiMessage::from(*event))).map_err(|_| Error::WriteError);
+    }
+
+    fn write_sysex(&mut self, event: &[u8]) -> Result<(), Error> {
+        return OutputPort::write_sysex(self, 0, event).map_err(|_| Error::WriteError);
+    }
+}
+
+impl<'a> Writer<Event> for (InputPort<'a>, OutputPort<'a>) {
+    fn write_midi(&mut self, event: &[u8; 4]) -> Result<(), Error> {
+        return Writer::write_midi(&mut self.1, event);
+    }
+
+    fn write_sysex(&mut self, event: &[u8]) -> Result<(), Error> {
+        return Writer::write_sysex(&mut self.1, event);
+    }
+}

--- a/src/midi/launchpadpro/device.rs
+++ b/src/midi/launchpadpro/device.rs
@@ -1,0 +1,35 @@
+use std::convert::From;
+use crate::midi::{InputPort, OutputPort, Reader, Writer, Error};
+use super::LaunchpadProEvent;
+
+pub struct LaunchpadPro<'a> {
+    device: (InputPort<'a>, OutputPort<'a>),
+}
+
+impl<'a> From<(InputPort<'a>, OutputPort<'a>)> for LaunchpadPro<'a> {
+    fn from(ports: (InputPort<'a>, OutputPort<'a>)) -> LaunchpadPro<'a> {
+        return LaunchpadPro { device: ports };
+    }
+}
+
+impl<'a> From<LaunchpadPro<'a>> for (InputPort<'a>, OutputPort<'a>) {
+    fn from(launchpadpro: LaunchpadPro<'a>) -> (InputPort<'a>, OutputPort<'a>) {
+        return launchpadpro.device;
+    }
+}
+
+impl Reader<LaunchpadProEvent> for LaunchpadPro<'_> {
+    fn read_midi(&mut self) -> Result<Option<[u8; 4]>, Error> {
+        return Reader::read_midi(&mut self.device);
+    }
+}
+
+impl Writer<LaunchpadProEvent> for LaunchpadPro<'_> {
+    fn write_midi(&mut self, event: &[u8; 4]) -> Result<(), Error> {
+        return Writer::write_midi(&mut self.device, event);
+    }
+
+    fn write_sysex(&mut self, event: &[u8]) -> Result<(), Error> {
+        return Writer::write_sysex(&mut self.device, event);
+    }
+}

--- a/src/midi/launchpadpro/event/image.rs
+++ b/src/midi/launchpadpro/event/image.rs
@@ -1,0 +1,122 @@
+use crate::image::{Image, scale};
+use crate::midi::{FromImage, FromImages, Error, Event};
+use super::LaunchpadProEvent;
+
+const WIDTH: usize = 8;
+const HEIGHT: usize = 8;
+const SIZE: usize = WIDTH * HEIGHT;
+
+impl FromImage<LaunchpadProEvent> for LaunchpadProEvent {
+    fn from_image(image: Image) -> Result<Self, Error> {
+        let scaled_image = scale(&image, WIDTH, HEIGHT).map_err(|_| Error::ImageRenderError)?;
+        return render_24bit_image_reversed(scaled_image.bytes);
+    }
+}
+
+impl FromImages<LaunchpadProEvent> for LaunchpadProEvent {
+    fn from_images(images: Vec<Image>) -> Result<Self, Error> {
+        return match images.len() {
+            1 => render_one_image(&images[0]),
+            SIZE => render_one_image_per_pad(&images),
+            _ => {
+                println!("[launchpadpro] unsupported number of images: {}", images.len());
+                return Err(Error::ImageRenderError);
+            },
+        }
+    }
+}
+
+fn render_one_image(image: &Image) -> Result<LaunchpadProEvent, Error> {
+    let scaled_image = scale(image, WIDTH, HEIGHT).map_err(|_| Error::ImageRenderError)?;
+    return render_24bit_image_reversed(scaled_image.bytes);
+}
+
+fn render_one_image_per_pad(images: &Vec<Image>) -> Result<LaunchpadProEvent, Error> {
+    let fallback_pixel = Image { width: 1, height: 1, bytes: vec![0; 3] };
+    let mosaic = images.into_iter()
+        .map(|image| scale(image, 1, 1).unwrap_or(fallback_pixel.clone()))
+        .flat_map(|image| image.bytes)
+        .collect::<Vec<u8>>();
+    return render_24bit_image(mosaic);
+}
+
+/// The LaunchpadPro’s coordinate system places the origin at the bottom-left corner, so we
+/// need to give an easy option to render an image with (0,0) being the top-left corner.
+fn render_24bit_image_reversed(bytes: Vec<u8>) -> Result<LaunchpadProEvent, Error> {
+    let reversed_bytes = reverse_rows(bytes)?;
+    return render_24bit_image(reversed_bytes);
+}
+
+fn render_24bit_image(bytes: Vec<u8>) -> Result<LaunchpadProEvent, Error> {
+    // one byte for each color
+    let size = SIZE * 3;
+
+    if bytes.len() != size {
+        println!("[launchpadpro] error when trying to render an image with {} bytes", bytes.len());
+        return Err(Error::ImageRenderError);
+    }
+
+    let mut picture = Vec::with_capacity(size);
+    picture.append(&mut vec![240, 0, 32, 41, 2, 16, 15, 1]);
+    for byte in bytes {
+        // The LaunchpadPro also only supports values from the [0; 64[ range, so we need to make sure
+        // that our 24-bit-RGB-color bytes get transformed.
+        picture.push(byte / 4);
+    }
+    picture.append(&mut vec![247]);
+
+    return Ok(LaunchpadProEvent { event: Event::SysEx(picture) });
+}
+
+fn reverse_rows(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
+    // one byte for each color
+    let size = SIZE * 3;
+
+    if bytes.len() != size {
+        println!("[launchpadpro] error when trying to render an image with {} bytes", bytes.len());
+        return Err(Error::ImageRenderError);
+    }
+
+    let mut reversed_bytes = vec![0; size];
+
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            for c in 0..3 {
+                reversed_bytes[3 * (y * WIDTH + x) + c] = bytes[3 * ((HEIGHT - 1 - y) * WIDTH + x) + c];
+            }
+        }
+    }
+
+    return Ok(reversed_bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reverse_rows() {
+        let input = vec![
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+            2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+            3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,
+            4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+            5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+            6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+            7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+        ];
+
+        let actual_output = reverse_rows(input).expect("Test input is expected to be valid");
+        assert_eq!(actual_output, vec![
+            7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+            6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+            5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+            4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+            3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,
+            2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        ]);
+    }
+}

--- a/src/midi/launchpadpro/event/index.rs
+++ b/src/midi/launchpadpro/event/index.rs
@@ -1,0 +1,96 @@
+use crate::midi::{Event, Error, IntoIndex};
+use super::LaunchpadProEvent;
+
+impl IntoIndex for LaunchpadProEvent {
+    fn into_index(self) ->  Result<Option<u16>, Error> {
+        return Ok(match self.event {
+            // event must be a "note down" with a strictly positive velocity
+            Event::Midi([144, data1, data2, _]) if data2 > 0 => {
+                // the device provides a 10x10 grid if you count the buttons on the sides
+                let row = data1 / 10;
+                let column  = data1 % 10;
+
+                // but in this implementation, we’ll only focus on the central 8x8 grid
+                if row >= 1 && row <= 8 && column >= 1 && column <= 8 {
+                    Some((row - 1) * 8 + (column - 1)).map(|index| index.into())
+                } else {
+                    None
+                }
+            },
+            _ => None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn into_index_given_incorrect_status_should_return_none() {
+        let event = LaunchpadProEvent { event: Event::Midi([128, 53, 10, 0]) };
+        assert_eq!(None, event.into_index().expect("into_index should not fail"));
+    }
+
+    #[test]
+    fn into_index_given_low_velocity_should_return_none() {
+        let event = LaunchpadProEvent { event: Event::Midi([144, 53, 0, 0]) };
+        assert_eq!(None, event.into_index().expect("into_index should not fail"));
+    }
+
+    #[test]
+    fn into_index_given_out_of_grid_value_should_return_none() {
+        let events = vec![
+            [144, 00, 10, 0],
+            [144, 01, 10, 0],
+            [144, 08, 10, 0],
+            [144, 08, 10, 0],
+            [144, 10, 10, 0],
+            [144, 19, 10, 0],
+            [144, 80, 10, 0],
+            [144, 89, 10, 0],
+            [144, 90, 10, 0],
+            [144, 91, 10, 0],
+            [144, 98, 10, 0],
+            [144, 99, 10, 0],
+        ];
+
+        for event in events {
+            let launchpadpro_event = LaunchpadProEvent { event: Event::Midi(event) };
+            assert_eq!(None, launchpadpro_event.into_index().expect("into_index should not fail"));
+        }
+    }
+
+    #[test]
+    fn into_index_should_correct_value() {
+        let actual_output = vec![
+            81, 82, 83, 84, 85, 86, 87, 88,
+            71, 72, 73, 74, 75, 76, 77, 78,
+            61, 62, 63, 64, 65, 66, 67, 68,
+            51, 52, 53, 54, 55, 56, 57, 58,
+            41, 42, 43, 44, 45, 46, 47, 48,
+            31, 32, 33, 34, 35, 36, 37, 38,
+            21, 22, 23, 24, 25, 26, 27, 28,
+            11, 12, 13, 14, 15, 16, 17, 18,
+        ]
+            .iter()
+            .map(|code| (LaunchpadProEvent { event: Event::Midi([144, *code, 10, 0]) }).into_index().expect("into_index should not fail"))
+            .collect::<Vec<Option<u16>>>();
+
+        let expected_output = vec![
+            56, 57, 58, 59, 60, 61, 62, 63,
+            48, 49, 50, 51, 52, 53, 54, 55,
+            40, 41, 42, 43, 44, 45, 46, 47,
+            32, 33, 34, 35, 36, 37, 38, 39,
+            24, 25, 26, 27, 28, 29, 30, 31,
+            16, 17, 18, 19, 20, 21, 22, 23,
+            08, 09, 10, 11, 12, 13, 14, 15,
+            00, 01, 02, 03, 04, 05, 06, 07,
+        ]
+            .iter()
+            .map(|index| Some(*index))
+            .collect::<Vec<Option<u16>>>();
+
+        assert_eq!(expected_output, actual_output);
+    }
+}

--- a/src/midi/launchpadpro/event/mod.rs
+++ b/src/midi/launchpadpro/event/mod.rs
@@ -1,0 +1,21 @@
+use std::convert::From;
+use crate::midi::Event;
+
+mod image;
+mod index;
+
+pub struct LaunchpadProEvent {
+    event: Event,
+}
+
+impl From<Event> for LaunchpadProEvent {
+    fn from(event: Event) -> LaunchpadProEvent {
+        return LaunchpadProEvent { event };
+    }
+}
+
+impl From<LaunchpadProEvent> for Event {
+    fn from(event: LaunchpadProEvent) -> Event {
+        return event.event;
+    }
+}

--- a/src/midi/launchpadpro/event/mod.rs
+++ b/src/midi/launchpadpro/event/mod.rs
@@ -4,6 +4,7 @@ use crate::midi::Event;
 mod image;
 mod index;
 
+#[derive(Clone, Debug)]
 pub struct LaunchpadProEvent {
     event: Event,
 }

--- a/src/midi/launchpadpro/mod.rs
+++ b/src/midi/launchpadpro/mod.rs
@@ -1,259 +1,45 @@
-use std::convert::From;
-use crate::image::{Image, scale};
-use super::{InputPort, OutputPort, MidiEvent, Error, Reader, Writer, ImageRenderer, IndexReader};
+mod device;
+mod event;
 
-pub struct LaunchpadPro<'a> {
-    input_port: InputPort<'a>,
-    output_port: OutputPort<'a>,
-}
-
-impl LaunchpadPro<'_> {
-    pub const WIDTH: usize = 8;
-    pub const HEIGHT: usize = 8;
-    pub const SIZE: usize = Self::WIDTH * Self::HEIGHT;
-
-    fn render_one_image(&mut self, image: &Image) -> Result<(), Error> {
-        let scaled_image = scale(image, Self::WIDTH, Self::HEIGHT).map_err(|_| Error::ImageRenderError)?;
-        return self.render_24bit_image_reversed(scaled_image.bytes);
-    }
-
-    fn render_one_image_per_pad(&mut self, images: &Vec<Image>) -> Result<(), Error> {
-        let fallback_pixel = Image { width: 1, height: 1, bytes: vec![0; 3] };
-        let mosaic = images.into_iter()
-            .map(|image| scale(image, 1, 1).unwrap_or(fallback_pixel.clone()))
-            .flat_map(|image| image.bytes)
-            .collect::<Vec<u8>>();
-        return self.render_24bit_image(mosaic);
-    }
-
-    /// The LaunchpadPro’s coordinate system places the origin at the bottom-left corner, so we
-    /// need to give an easy option to render an image with (0,0) being the top-left corner.
-    fn render_24bit_image_reversed(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
-        let reversed_bytes = Self::reverse_rows(bytes)?;
-        return self.render_24bit_image(reversed_bytes);
-    }
-
-    fn render_24bit_image(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
-        // one byte for each color
-        let size = Self::SIZE * 3;
-
-        if bytes.len() != size {
-            println!("[launchpadpro] error when trying to render an image with {} bytes", bytes.len());
-            return Err(Error::ImageRenderError);
-        }
-
-        let mut picture = Vec::with_capacity(size);
-        picture.append(&mut vec![240, 0, 32, 41, 2, 16, 15, 1]);
-        for byte in bytes {
-            // The LaunchpadPro also only supports values from the [0; 64[ range, so we need to make sure
-            // that our 24-bit-RGB-color bytes get transformed.
-            picture.push(byte / 4);
-        }
-        picture.append(&mut vec![247]);
-
-        return self.output_port.write_sysex(0, &picture)
-            .map_err(|_| Error::ImageRenderError);
-    }
-
-    fn reverse_rows(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
-        // one byte for each color
-        let size = Self::SIZE * 3;
-
-        if bytes.len() != size {
-            println!("[launchpadpro] error when trying to render an image with {} bytes", bytes.len());
-            return Err(Error::ImageRenderError);
-        }
-
-        let mut reversed_bytes = vec![0; size];
-
-        for y in 0..Self::HEIGHT {
-            for x in 0..Self::WIDTH {
-                for c in 0..3 {
-                    reversed_bytes[3 * (y * Self::WIDTH + x) + c] = bytes[3 * ((Self::HEIGHT - 1 - y) * Self::WIDTH + x) + c];
-                }
-            }
-        }
-
-        return Ok(reversed_bytes);
-    }
-}
-
-impl<'a> From<(InputPort<'a>, OutputPort<'a>)> for LaunchpadPro<'a> {
-    fn from(ports: (InputPort<'a>, OutputPort<'a>)) -> LaunchpadPro<'a> {
-        return LaunchpadPro { input_port: ports.0, output_port: ports.1 };
-    }
-}
-
-impl Reader for LaunchpadPro<'_> {
-    fn read(&mut self) -> Result<Option<MidiEvent>, Error> {
-        let event = Reader::read(&mut self.input_port);
-        match event {
-            Ok(Some(event)) => println!("event: {:?}", event),
-            _ => {},
-        }
-        return event;
-    }
-}
-
-impl IndexReader for LaunchpadPro<'_> {
-    fn read_index(&mut self) -> Result<Option<u16>, Error> {
-        return Reader::read(self).map(|event| event.and_then(|event| map_event_to_index(event)));
-    }
-}
-
-pub fn map_event_to_index(event: MidiEvent) -> Option<u16> {
-    return Some(event)
-        // event must be a "note down"
-        .filter(|event| event.message.status == 144)
-        // event must have a strictly positive velocity
-        .filter(|event| event.message.data2 > 0)
-        // event must correspond to a square pad
-        // then map the index by starting from the grid’s bottom-left corner
-        .and_then(|event| {
-            let value = event.message.data1;
-            let row = value / 10;
-            let column  = value % 10;
-
-            if row >= 1 && row <= 8 && column >= 1 && column <= 8 {
-                return Some((row - 1) * 8 + (column - 1)).map(|index| index.into());
-            } else {
-                return None;
-            }
-        });
-}
-
-impl Writer for LaunchpadPro<'_> {
-    fn write(&mut self, event: &MidiEvent) -> Result<(), Error> {
-        return Writer::write(&mut self.output_port, event);
-    }
-}
-
-impl ImageRenderer<Vec<Image>> for LaunchpadPro<'_> {
-    fn render(&mut self, images: Vec<Image>) -> Result<(), Error> {
-        return match images.len() {
-            1 => self.render_one_image(&images[0]),
-            Self::SIZE => self.render_one_image_per_pad(&images),
-            _ => {
-                println!("[launchpadpro] unsupported number of images: {}", images.len());
-                return Err(Error::ImageRenderError);
-            },
-        }
-    }
-}
+pub use device::LaunchpadPro;
+pub use event::LaunchpadProEvent;
 
 #[cfg(test)]
-mod tests {
-    use super::super::MidiMessage;
-    use super::*;
-
-    #[test]
-    fn test_reverse_rows() {
-        let input = vec![
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-            2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
-            3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,
-            4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
-            5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
-            6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-            7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-        ];
-
-        let actual_output = LaunchpadPro::reverse_rows(input).expect("Test input is expected to be valid");
-        assert_eq!(actual_output, vec![
-            7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-            6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-            5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
-            4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
-            3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,
-            2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
-            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-        ]);
-    }
-
-    #[test]
-    fn map_event_to_index_given_incorrect_status_should_return_none() {
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([128, 53, 10, 0]))));
-    }
-
-    #[test]
-    fn map_event_to_index_given_low_velocity_should_return_none() {
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 53, 0, 0]))));
-    }
-
-    #[test]
-    fn map_event_to_index_given_out_of_grid_value_should_return_none() {
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 00, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 01, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 08, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 08, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 10, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 19, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 80, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 89, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 90, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 91, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 98, 10, 0]))));
-        assert_eq!(None, map_event_to_index(MidiEvent::from(MidiMessage::from([144, 99, 10, 0]))));
-    }
-
-    #[test]
-    fn map_event_to_index_should_correct_value() {
-        let actual_output = vec![
-            81, 82, 83, 84, 85, 86, 87, 88,
-            71, 72, 73, 74, 75, 76, 77, 78,
-            61, 62, 63, 64, 65, 66, 67, 68,
-            51, 52, 53, 54, 55, 56, 57, 58,
-            41, 42, 43, 44, 45, 46, 47, 48,
-            31, 32, 33, 34, 35, 36, 37, 38,
-            21, 22, 23, 24, 25, 26, 27, 28,
-            11, 12, 13, 14, 15, 16, 17, 18,
-        ]
-            .iter()
-            .map(|code| map_event_to_index(MidiEvent::from(MidiMessage::from([144, *code, 10, 0]))))
-            .collect::<Vec<Option<u16>>>();
-
-        let expected_output = vec![
-            56, 57, 58, 59, 60, 61, 62, 63,
-            48, 49, 50, 51, 52, 53, 54, 55,
-            40, 41, 42, 43, 44, 45, 46, 47,
-            32, 33, 34, 35, 36, 37, 38, 39,
-            24, 25, 26, 27, 28, 29, 30, 31,
-            16, 17, 18, 19, 20, 21, 22, 23,
-            08, 09, 10, 11, 12, 13, 14, 15,
-            00, 01, 02, 03, 04, 05, 06, 07,
-        ]
-            .iter()
-            .map(|index| Some(*index))
-            .collect::<Vec<Option<u16>>>();
-
-        assert_eq!(expected_output, actual_output);
-    }
-
+mod test {
     #[test]
     #[cfg(feature = "launchpadpro")]
     fn render_rainbow() {
-        use crate::midi::Connections;
+        use std::convert::From;
+        use crate::image::Image;
+        use crate::midi::{Connections, FromImage, Writer};
+        use super::*;
 
         let connections = Connections::new().unwrap();
         let ports = connections.create_bidirectional_ports(&"Launchpad Pro Standalone Port".to_string());
         match ports {
             Ok(ports) => {
                 let mut launchpadpro = LaunchpadPro::from(ports);
-                let mut bytes = vec![0u8; LaunchpadPro::SIZE * 3];
+                let mut bytes = vec![0u8; 192];
 
-                for y in 0..LaunchpadPro::HEIGHT {
-                    for x in 0..LaunchpadPro::WIDTH {
+                for y in 0..8 {
+                    for x in 0..8 {
                         let index = x + y;
-                        let max = (LaunchpadPro::WIDTH - 1) + (LaunchpadPro::HEIGHT - 1);
-                        bytes[3 * (y * LaunchpadPro::WIDTH + x) + 0] = (255 - 255 * index / max) as u8;
-                        bytes[3 * (y * LaunchpadPro::WIDTH + x) + 1] = 0;
-                        bytes[3 * (y * LaunchpadPro::WIDTH + x) + 2] = (255 * index / max) as u8;
+                        bytes[3 * (y * 8 + x) + 0] = (255 - 255 * index / 14) as u8;
+                        bytes[3 * (y * 8 + x) + 1] = 0;
+                        bytes[3 * (y * 8 + x) + 2] = (255 * index / 14) as u8;
                     }
                 }
 
-                let result = launchpadpro.render_24bit_image_reversed(bytes);
+                let image = Image {
+                    width: 8,
+                    height: 8,
+                    bytes,
+                };
+
+                let result = LaunchpadProEvent::from_image(image).and_then(|event| {
+                    return launchpadpro.write(event);
+                });
+
                 assert!(result.is_ok(), "The LaunchpadPro could not render the given image");
             },
             Err(_) => {

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -1,9 +1,11 @@
 mod command;
 mod connections;
+mod device;
 mod error;
 
 pub use command::*;
 pub use connections::{Connections, InputPort, OutputPort};
+pub use device::*;
 pub use error::Error;
 
 /// MIDI vendors


### PR DESCRIPTION
The `Spotify` app will now send and receive MIDI events, that will make it able to control how it interacts with the MIDI device. Because `portmidi` will crash if you use it in different threads, the `midi` logic has been redesigned so that sending/receiving events is decoupled from event transformation.