### PR TITLE
Make the square pads blink!

### DIFF
--- a/src/midi/command.rs
+++ b/src/midi/command.rs
@@ -29,3 +29,8 @@ pub trait FromImage<T> {
 pub trait FromImages<T> {
     fn from_images(images: Vec<Image>) -> Result<T, Error>;
 }
+
+/// MIDI Device that is able to highlight a note/square pad at a specific index
+pub trait FromSelectedIndex<T> {
+    fn from_selected_index(index: u16) -> Result<T, Error>;
+}

--- a/src/midi/error.rs
+++ b/src/midi/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     ReadError,
     WriteError,
     ImageRenderError,
+    OutOfBoundIndexError,
 }
 
 impl fmt::Display for Error {
@@ -21,6 +22,7 @@ impl fmt::Display for Error {
             Error::ReadError => write!(f, "[midi] could not read an event"),
             Error::WriteError => write!(f, "[midi] could not write an event"),
             Error::ImageRenderError => write!(f, "[midi] could not render image"),
+            Error::OutOfBoundIndexError => write!(f, "[midi] could not handle index"),
         }
     }
 }

--- a/src/midi/launchpadpro/event/index.rs
+++ b/src/midi/launchpadpro/event/index.rs
@@ -1,4 +1,4 @@
-use crate::midi::{Event, Error, IntoIndex};
+use crate::midi::{Event, Error, IntoIndex, FromSelectedIndex};
 use super::LaunchpadProEvent;
 
 impl IntoIndex for LaunchpadProEvent {
@@ -19,6 +19,22 @@ impl IntoIndex for LaunchpadProEvent {
             },
             _ => None,
         });
+    }
+}
+
+impl FromSelectedIndex<LaunchpadProEvent> for LaunchpadProEvent {
+    fn from_selected_index(index: u16) -> Result<LaunchpadProEvent, Error> {
+        if index > 63 {
+            return Err(Error::OutOfBoundIndexError);
+        }
+
+        let index = index as u8;
+        let row = index / 8 + 1;
+        let column = index % 8 + 1;
+        let led = row * 10 + column;
+
+        let bytes = vec![240, 0, 32, 41, 2, 16, 40, led, 3, 247];
+        return Ok(LaunchpadProEvent::from(Event::SysEx(bytes)));
     }
 }
 

--- a/src/midi/launchpadpro/mod.rs
+++ b/src/midi/launchpadpro/mod.rs
@@ -8,10 +8,10 @@ pub use event::LaunchpadProEvent;
 mod test {
     #[test]
     #[cfg(feature = "launchpadpro")]
-    fn render_rainbow() {
+    fn render_rainbow_and_blink() {
         use std::convert::From;
         use crate::image::Image;
-        use crate::midi::{Connections, FromImage, Writer};
+        use crate::midi::{Connections, FromImage, FromSelectedIndex, Writer};
         use super::*;
 
         let connections = Connections::new().unwrap();
@@ -41,6 +41,12 @@ mod test {
                 });
 
                 assert!(result.is_ok(), "The LaunchpadPro could not render the given image");
+
+                let result = LaunchpadProEvent::from_selected_index(27).and_then(|event| {
+                    return launchpadpro.write(event);
+                });
+
+                assert!(result.is_ok(), "The LaunchpadPro could not make the square pad blink");
             },
             Err(_) => {
                 println!("The LaunchpadPro device may not be connected correctly");


### PR DESCRIPTION
After a user has pressed a square pad to play a Spotify song, let’s make it blink to reflect that the song is currently playing.
The next step is to actually poll the play state from Spotify to make it automatically stop blinking once the song is over, or pause the song if the user presses the pad again before the song is over.