### PR TITLE
Implement app selection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn args() -> Result<Config, String> {
         },
         Some("run") => {
             return match &args[2..] {
-                [client_id, client_secret, input_name, output_name, spotify_selector, playlist_id, token, youtube_device, youtube_api_key, youtube_playlist_id] => Ok(Config::RunConfig {
+                [client_id, client_secret, input_name, output_name, launchpad_name, playlist_id, token, youtube_api_key, youtube_playlist_id] => Ok(Config::RunConfig {
                     config: router::RunConfig {
                         spotify_app_config: spotify::SpotifyAppConfig {
                             authorization: spotify::authorization::SpotifyAuthorizationConfig {
@@ -75,13 +75,12 @@ fn args() -> Result<Config, String> {
                         },
                         input_name: String::from(input_name),
                         output_name: String::from(output_name),
-                        spotify_selector: String::from(spotify_selector),
-                        youtube_device: String::from(youtube_device),
+                        launchpad_name: String::from(launchpad_name),
                         youtube_api_key: String::from(youtube_api_key),
                         youtube_playlist_id: String::from(youtube_playlist_id),
                     },
                 }),
-                _ => Err(String::from("Usage: ./midi-hub run <client-id> <client-secret> <input-name> <output-name> <spotify-selector> <playlist-id> <spotify-token> <youtube-device> <youtube-api-key> <youtube-playlist-id>")),
+                _ => Err(String::from("Usage: ./midi-hub run <client-id> <client-secret> <input-name> <output-name> <launchpad-name> <playlist-id> <spotify-token> <youtube-api-key> <youtube-playlist-id>")),
             };
         },
         _ => Err(String::from("Usage ./midi-hub [login|run] <args>")),

--- a/src/midi/command.rs
+++ b/src/midi/command.rs
@@ -20,6 +20,11 @@ impl IntoIndex for [u8; 4] {
     }
 }
 
+/// MIDI Device that has the capability of switching applications
+pub trait IntoAppIndex {
+    fn into_app_index(self) -> Result<Option<u16>, Error>;
+}
+
 /// MIDI Device that is able to render a picture
 pub trait FromImage<T> {
     fn from_image(image: Image) -> Result<T, Error>;

--- a/src/midi/command.rs
+++ b/src/midi/command.rs
@@ -39,3 +39,8 @@ pub trait FromImages<T> {
 pub trait FromSelectedIndex<T> {
     fn from_selected_index(index: u16) -> Result<T, Error>;
 }
+
+/// MIDI Device that is able to highlight "app selection" buttons with correct colors
+pub trait FromAppColors<T> {
+    fn from_app_colors(app_colors: Vec<[u8; 3]>) -> Result<T, Error>;
+}

--- a/src/midi/launchpadpro/event/index.rs
+++ b/src/midi/launchpadpro/event/index.rs
@@ -1,4 +1,4 @@
-use crate::midi::{Event, Error, IntoIndex, FromSelectedIndex};
+use crate::midi::{Event, Error, IntoIndex, IntoAppIndex, FromSelectedIndex};
 use super::LaunchpadProEvent;
 
 impl IntoIndex for LaunchpadProEvent {
@@ -13,6 +13,27 @@ impl IntoIndex for LaunchpadProEvent {
                 // but in this implementation, we’ll only focus on the central 8x8 grid
                 if row >= 1 && row <= 8 && column >= 1 && column <= 8 {
                     Some((row - 1) * 8 + (column - 1)).map(|index| index.into())
+                } else {
+                    None
+                }
+            },
+            _ => None,
+        });
+    }
+}
+
+impl IntoAppIndex for LaunchpadProEvent {
+    fn into_app_index(self) ->  Result<Option<u16>, Error> {
+        return Ok(match self.event {
+            // event must be a "note down" with a strictly positive velocity
+            Event::Midi([176, data1, data2, _]) if data2 > 0 => {
+                // the device provides a 10x10 grid if you count the buttons on the sides
+                let row = data1 / 10;
+                let column  = data1 % 10;
+
+                // we’ll use the last column on the right to select applications
+                if row >= 1 && row <= 8 && column == 9 {
+                    Some(8 - row).map(|index| index.into())
                 } else {
                     None
                 }
@@ -103,6 +124,56 @@ mod tests {
             08, 09, 10, 11, 12, 13, 14, 15,
             00, 01, 02, 03, 04, 05, 06, 07,
         ]
+            .iter()
+            .map(|index| Some(*index))
+            .collect::<Vec<Option<u16>>>();
+
+        assert_eq!(expected_output, actual_output);
+    }
+
+    #[test]
+    fn into_app_index_given_incorrect_status_should_return_none() {
+        let event = LaunchpadProEvent { event: Event::Midi([128, 89, 10, 0]) };
+        assert_eq!(None, event.into_app_index().expect("into_app_index should not fail"));
+    }
+
+    #[test]
+    fn into_app_index_given_low_velocity_should_return_none() {
+        let event = LaunchpadProEvent { event: Event::Midi([176, 89, 0, 0]) };
+        assert_eq!(None, event.into_app_index().expect("into_app_index should not fail"));
+    }
+
+    #[test]
+    fn into_app_index_given_out_of_grid_value_should_return_none() {
+        let events = vec![
+            [176, 08, 10, 0],
+            [176, 09, 10, 0],
+            [176, 18, 10, 0],
+            [176, 28, 10, 0],
+            [176, 38, 10, 0],
+            [176, 48, 10, 0],
+            [176, 58, 10, 0],
+            [176, 68, 10, 0],
+            [176, 78, 10, 0],
+            [176, 88, 10, 0],
+            [176, 98, 10, 0],
+            [176, 99, 10, 0],
+        ];
+
+        for event in events {
+            let launchpadpro_event = LaunchpadProEvent { event: Event::Midi(event) };
+            assert_eq!(None, launchpadpro_event.into_app_index().expect("into_app_index should not fail"));
+        }
+    }
+
+    #[test]
+    fn into_app_index_should_correct_value() {
+        let actual_output = vec![19, 29, 39, 49, 59, 69, 79, 89]
+            .iter()
+            .map(|code| (LaunchpadProEvent { event: Event::Midi([176, *code, 10, 0]) }).into_app_index().expect("into_app_index should not fail"))
+            .collect::<Vec<Option<u16>>>();
+
+        let expected_output = vec![7, 6, 5, 4, 3, 2, 1, 0]
             .iter()
             .map(|index| Some(*index))
             .collect::<Vec<Option<u16>>>();

--- a/src/midi/launchpadpro/event/index.rs
+++ b/src/midi/launchpadpro/event/index.rs
@@ -54,7 +54,7 @@ impl FromSelectedIndex<LaunchpadProEvent> for LaunchpadProEvent {
         let column = index % 8 + 1;
         let led = row * 10 + column;
 
-        let bytes = vec![240, 0, 32, 41, 2, 16, 40, led, 3, 247];
+        let bytes = vec![240, 0, 32, 41, 2, 16, 40, led, 45, 247];
         return Ok(LaunchpadProEvent::from(Event::SysEx(bytes)));
     }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 use crate::spotify;
 use crate::midi;
 use crate::youtube;
-use midi::{Connections, Error, Event, Reader, Writer, IntoAppIndex, FromImage};
+use midi::{Connections, Error, Event, Reader, Writer, IntoAppIndex, FromImage, FromAppColors};
 use midi::launchpadpro::{LaunchpadPro, LaunchpadProEvent};
 use crate::youtube::server::HttpServer;
 
@@ -99,6 +99,11 @@ impl Router {
 
                 let launchpad_result = match launchpad.as_mut() {
                     Ok(launchpad) => {
+                        let _ = LaunchpadProEvent::from_app_colors(vec![
+                            spotify::COLOR,
+                            youtube::app::COLOR,
+                        ]).and_then(|event| launchpad.write(event));
+
                         match self.selected_app {
                             AppName::Spotify => {
                                 let event = self.spotify_receiver.try_recv();

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -10,19 +10,23 @@ use tokio::sync::mpsc;
 use crate::spotify;
 use crate::midi;
 use crate::youtube;
-use midi::{Connections, Error, Event, Reader, Writer};
+use midi::{Connections, Error, Event, Reader, Writer, IntoAppIndex};
 use midi::launchpadpro::{LaunchpadPro, LaunchpadProEvent};
 use crate::youtube::server::HttpServer;
 
 const MIDI_DEVICE_POLL_INTERVAL: Duration = Duration::from_millis(10_000);
 const MIDI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+enum AppName {
+    Spotify,
+    Youtube,
+}
+
 pub struct RunConfig {
     pub spotify_app_config: spotify::SpotifyAppConfig,
     pub input_name: String,
     pub output_name: String,
-    pub spotify_selector: String,
-    pub youtube_device: String,
+    pub launchpad_name: String,
     pub youtube_api_key: String,
     pub youtube_playlist_id: String,
 }
@@ -30,19 +34,20 @@ pub struct RunConfig {
 pub struct Router {
     config: RunConfig,
     term: Arc<AtomicBool>,
-    spotify_spawner: spotify::SpotifyTaskSpawner<LaunchpadProEvent>,
-    receiver: mpsc::Receiver<LaunchpadProEvent>,
+    spotify_app: spotify::SpotifyTaskSpawner<LaunchpadProEvent>,
+    spotify_receiver: mpsc::Receiver<LaunchpadProEvent>,
     youtube_server: HttpServer,
     youtube_app: youtube::app::Youtube<LaunchpadProEvent>,
     youtube_receiver: mpsc::Receiver<youtube::Out<LaunchpadProEvent>>,
+    selected_app: AppName,
 }
 
 impl Router {
     pub fn new(config: RunConfig) -> Self {
         let term = Arc::new(AtomicBool::new(false));
 
-        let (sender, receiver) = mpsc::channel::<LaunchpadProEvent>(32);
-        let spotify_spawner = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone(), sender);
+        let (sp_sender, sp_receiver) = mpsc::channel::<LaunchpadProEvent>(32);
+        let spotify_app = spotify::SpotifyTaskSpawner::new(config.spotify_app_config.clone(), sp_sender);
         let youtube_server = HttpServer::start();
         let (yt_sender, yt_receiver) = mpsc::channel::<youtube::Out<LaunchpadProEvent>>(32);
         let youtube_app = youtube::app::Youtube::new(config.youtube_api_key.clone(), config.youtube_playlist_id.clone(), yt_sender);
@@ -50,11 +55,12 @@ impl Router {
         return Router {
             config,
             term,
-            spotify_spawner,
-            receiver,
+            spotify_app,
+            spotify_receiver: sp_receiver,
             youtube_server,
             youtube_app,
             youtube_receiver: yt_receiver,
+            selected_app: AppName::Spotify,
         };
     }
 
@@ -73,9 +79,7 @@ impl Router {
         return Connections::new().and_then(|connections| {
             let mut input = connections.create_input_port(&self.config.input_name);
             let mut output = connections.create_output_port(&self.config.output_name);
-            let mut spotify = connections.create_bidirectional_ports(&self.config.spotify_selector)
-                .map(|ports| LaunchpadPro::from(ports));
-            let mut youtube_ports = connections.create_bidirectional_ports(&self.config.youtube_device)
+            let mut launchpad = connections.create_bidirectional_ports(&self.config.launchpad_name)
                 .map(|ports| LaunchpadPro::from(ports));
 
             let mut result = Ok(());
@@ -93,19 +97,50 @@ impl Router {
                     (_, Err(e)) => Err(*e),
                 };
 
-                let spotify_result = match spotify.as_mut() {
-                    Ok(spotify) => {
-                        let event = self.receiver.try_recv();
-                        match event {
-                            Ok(event) => {
-                                let _ = spotify.write(event);
+                let launchpad_result = match launchpad.as_mut() {
+                    Ok(launchpad) => {
+                        match self.selected_app {
+                            AppName::Spotify => {
+                                let event = self.spotify_receiver.try_recv();
+                                match event {
+                                    Ok(event) => {
+                                        let _ = launchpad.write(event);
+                                    },
+                                    _ => {},
+                                }
                             },
-                            _ => {},
+                            AppName::Youtube => {
+                                let command = self.youtube_receiver.try_recv();
+                                match command {
+                                    Ok(youtube::Out::Command(command)) => {
+                                        let _ = self.youtube_server.send(command);
+                                    },
+                                    Ok(youtube::Out::Event(event)) => {
+                                        let _ = launchpad.write(event);
+                                    },
+                                    _ => {},
+                                }
+                            },
                         }
 
-                        match spotify.read() {
+                        match launchpad.read() {
                             Ok(Some(event)) => {
-                                self.spotify_spawner.handle(event);
+                                match event.clone().into_app_index() {
+                                    Ok(Some(0)) => {
+                                        println!("Selecting Spotify");
+                                        self.selected_app = AppName::Spotify;
+                                    },
+                                    Ok(Some(1)) => {
+                                        println!("Selecting Youtube");
+                                        self.selected_app = AppName::Youtube;
+                                    },
+                                    _ => {
+                                        match self.selected_app {
+                                            AppName::Spotify => self.spotify_app.handle(event),
+                                            AppName::Youtube => self.youtube_app.handle(event),
+                                        }
+                                    },
+                                }
                                 Ok(())
                             },
                             _ => Ok(()),
@@ -114,31 +149,7 @@ impl Router {
                     Err(e) => Err(*e),
                 };
 
-                let youtube_result = match youtube_ports.as_mut() {
-                    Ok(youtube_ports) => {
-                        let command = self.youtube_receiver.try_recv();
-                        match command {
-                            Ok(youtube::Out::Command(command)) => {
-                                let _ = self.youtube_server.send(command);
-                            },
-                            Ok(youtube::Out::Event(event)) => {
-                                let _ = youtube_ports.write(event);
-                            },
-                            _ => {},
-                        }
-
-                        match youtube_ports.read() {
-                            Ok(Some(event)) => {
-                                self.youtube_app.handle(event);
-                                Ok(())
-                            },
-                            _ => Ok(()),
-                        }
-                    },
-                    Err(e) => Err(*e),
-                };
-
-                result = forward_result.or(spotify_result).or(youtube_result);
+                result = forward_result.or(launchpad_result);
                 match result {
                     Ok(_) => thread::sleep(MIDI_EVENT_POLL_INTERVAL),
                     _ => thread::sleep(MIDI_DEVICE_POLL_INTERVAL),

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 use crate::spotify;
 use crate::midi;
 use crate::youtube;
-use midi::{Connections, Error, Event, Reader, Writer, IntoAppIndex};
+use midi::{Connections, Error, Event, Reader, Writer, IntoAppIndex, FromImage};
 use midi::launchpadpro::{LaunchpadPro, LaunchpadProEvent};
 use crate::youtube::server::HttpServer;
 
@@ -129,10 +129,14 @@ impl Router {
                                     Ok(Some(0)) => {
                                         println!("Selecting Spotify");
                                         self.selected_app = AppName::Spotify;
+                                        let _ = LaunchpadProEvent::from_image(spotify::get_spotify_logo())
+                                            .and_then(|event| launchpad.write(event));
                                     },
                                     Ok(Some(1)) => {
                                         println!("Selecting Youtube");
                                         self.selected_app = AppName::Youtube;
+                                        let _ = LaunchpadProEvent::from_image(youtube::app::get_youtube_logo())
+                                            .and_then(|event| launchpad.write(event));
                                     },
                                     _ => {
                                         match self.selected_app {

--- a/src/spotify/mod.rs
+++ b/src/spotify/mod.rs
@@ -265,6 +265,8 @@ async fn start_or_resume_index(token: String, state: Arc<State>, index: usize) -
     }
 }
 
+pub const COLOR: [u8; 3] = [0, 255, 0];
+
 pub fn get_spotify_logo() -> Image {
     let g = [0, 255, 0];
     let w = [255, 255, 255];

--- a/src/spotify/mod.rs
+++ b/src/spotify/mod.rs
@@ -68,7 +68,7 @@ impl<E: 'static> SpotifyTaskSpawner<E> {
         std::thread::spawn(move || {
             rt.block_on(async move {
                 pull_playlist_tracks(Arc::clone(&config_copy), Arc::clone(&state_copy)).await;
-                render_playlist_tracks(Arc::clone(&state_copy), Arc::clone(&sender)).await;
+                render_spotify_logo(Arc::clone(&state_copy), Arc::clone(&sender)).await;
                 while let Some(event) = recv.recv().await {
                     let config = Arc::clone(&config_copy);
                     let state = Arc::clone(&state_copy);
@@ -140,7 +140,7 @@ async fn handle_spotify_task<E>(config: Arc<SpotifyAppConfig>, state: Arc<State>
                         let mut playing = s.playing.lock().unwrap();
                         *playing = None;
                     }
-                    render_playlist_tracks(Arc::clone(&state), Arc::clone(&sender)).await;
+                    render_spotify_logo(Arc::clone(&state), Arc::clone(&sender)).await;
                 }
                 return res;
             }
@@ -165,7 +165,7 @@ async fn handle_spotify_task<E>(config: Arc<SpotifyAppConfig>, state: Arc<State>
                             let _ = sender.send(event).await;
                             sleep(DELAY).await;
                             pull_playlist_tracks(Arc::clone(&config), Arc::clone(&state)).await;
-                            render_playlist_tracks(Arc::clone(&state), Arc::clone(&sender)).await;
+                            render_spotify_logo(Arc::clone(&state), Arc::clone(&sender)).await;
                         },
                         Err(_) => {
                             println!("Could not download and decode {}", url);
@@ -196,26 +196,12 @@ async fn pull_playlist_tracks(config: Arc<SpotifyAppConfig>, state: Arc<State>) 
     }
 }
 
-async fn render_playlist_tracks<E>(state: Arc<State>, sender: Arc<mpsc::Sender<E>>) where
-    E: FromImages<E>,
+async fn render_spotify_logo<E>(state: Arc<State>, sender: Arc<mpsc::Sender<E>>) where
+    E: FromImage<E>,
     E: FromSelectedIndex<E>,
 {
-    let tracks = state.tracks.lock().unwrap().clone().unwrap_or(vec![]);
-
-    let mut images = Vec::with_capacity(tracks.len());
-    let fallback_image = Image { width: 64, height: 64, bytes: vec![0; 64*64*3] };
-
-    for n in 0..tracks.len() {
-        let image_url = tracks[n].album.images.last().map(|image| image.url.clone());
-        if image_url.is_some() {
-            images.push(Image::from_url(&image_url.unwrap()).await.unwrap_or(fallback_image.clone()));
-        } else {
-            images.push(fallback_image.clone());
-        }
-    };
-
-    match E::from_images(images) {
-        Err(_) => println!("[Spotify] could not render the playlist tracks"),
+    match E::from_image(get_spotify_logo()) {
+        Err(_) => println!("[Spotify] could not render the spotify logo"),
         Ok(event) => {
             let _ = sender.send(event).await;
         },
@@ -277,4 +263,24 @@ async fn start_or_resume_index(token: String, state: Arc<State>, index: usize) -
         Some(track) => client::player::play(token, track.uri.clone()).await.map(|()| track),
         _           => Err(SpotifyError::Unknown),
     }
+}
+
+pub fn get_spotify_logo() -> Image {
+    let g = [0, 255, 0];
+    let w = [255, 255, 255];
+
+    return Image {
+        width: 8,
+        height: 8,
+        bytes: vec![
+            g, g, g, g, g, g, g, g,
+            g, g, w, w, w, w, g, g,
+            g, w, g, g, g, g, w, g,
+            g, g, w, w, w, w, g, g,
+            g, w, g, g, g, g, w, g,
+            g, g, w, w, w, w, g, g,
+            g, w, g, g, g, g, w, g,
+            g, g, g, g, g, g, g, g,
+        ].concat(),
+    };
 }

--- a/src/youtube/app.rs
+++ b/src/youtube/app.rs
@@ -80,14 +80,11 @@ impl<E: 'static> Youtube<E> {
     }
 }
 
-async fn render_youtube_logo<E>(sender: Arc<mpsc::Sender<Out<E>>>) -> Result<(), ()> where
-    E: FromImage<E>,
-    E: std::fmt::Debug,
-{
+pub fn get_youtube_logo() -> Image {
     let r = [255, 0, 0];
     let w = [255, 255, 255];
 
-    let image = Image {
+    return Image {
         width: 8,
         height: 8,
         bytes: vec![
@@ -101,8 +98,13 @@ async fn render_youtube_logo<E>(sender: Arc<mpsc::Sender<Out<E>>>) -> Result<(),
             r, r, r, r, r, r, r, r,
         ].concat(),
     };
+}
 
-    let event = E::from_image(image).map_err(|err| {
+async fn render_youtube_logo<E>(sender: Arc<mpsc::Sender<Out<E>>>) -> Result<(), ()> where
+    E: FromImage<E>,
+    E: std::fmt::Debug,
+{
+    let event = E::from_image(get_youtube_logo()).map_err(|err| {
         eprintln!("Could not convert the image into a MIDI event: {:?}", err);
         ()
     })?;

--- a/src/youtube/app.rs
+++ b/src/youtube/app.rs
@@ -80,6 +80,8 @@ impl<E: 'static> Youtube<E> {
     }
 }
 
+pub const COLOR: [u8; 3] = [255, 0, 0];
+
 pub fn get_youtube_logo() -> Image {
     let r = [255, 0, 0];
     let w = [255, 255, 255];


### PR DESCRIPTION
Using a LaunchpadPro, you can now switch between Spotify and YouTube by using the top-right arrows. On that occasion, the Spotify app renders the Spotify logo instead of a mosaic of covers, to make a clearer distinction between the apps.