### PR TITLE
youtube: fix playback issue

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -69,25 +69,25 @@
     }
 
     if (youtubePlayer) {
-      youtubePlayer.loadVideoById(videoId, 0, 'hd720');
-    } else {
-      youtubePlayer = new YT.Player('youtube-player', {
-        height: '720',
-        width: '1280',
-        videoId,
-        events: {
-          onReady: () => youtubePlayer.playVideo(),
-          onStateChange: (event) => {
-            if (event.data === YT.PlayerState.PAUSED || event.data === YT.PlayerState.ENDED) {
-              youtubePlayer.destroy();
-              youtubePlayer = undefined;
-              console.log(ws);
-              ws.send(JSON.stringify('YoutubePause'));
-            }
-          },
-        }
-      });
+      youtubePlayer.destroy();
+      youtubePlayer = undefined;
     }
+
+    youtubePlayer = new YT.Player('youtube-player', {
+      height: '720',
+      width: '1280',
+      videoId,
+      events: {
+        onReady: () => youtubePlayer.playVideo(),
+        onStateChange: (event) => {
+          if (event.data === YT.PlayerState.PAUSED || event.data === YT.PlayerState.ENDED) {
+            youtubePlayer.destroy();
+            youtubePlayer = undefined;
+            ws.send(JSON.stringify('YoutubePause'));
+          }
+        },
+      }
+    });
   }
 
   const ws = new WebSocket("ws://localhost:54321/ws");


### PR DESCRIPTION
To avoid showing undesired video suggestions whenever the player pauses
or ends, we have configured the YouTube player to destroy in case of
such events.

The issue was that if the user was selecting a video to play while
another was already playing, the player would destroy (as the
ENDED event would be triggered for the first video) and the next video
would never play.

The quick and dirty way to fix this issue is to instantiate a new player
for each videoId. It could be cleaner to have some proper state
management in the web app, but this is not my primary focus right now.